### PR TITLE
Enable to set the transaction name on deploy and fix the max fee

### DIFF
--- a/packages/sdk/src/modules/transfers/DeployTransfer.ts
+++ b/packages/sdk/src/modules/transfers/DeployTransfer.ts
@@ -154,7 +154,6 @@ export class DeployTransfer extends BaseTransfer<CreateTransactionRequest> {
   ): Promise<CreateTransactionRequest> {
     const { vault: account, inputs, witnesses, ...transaction } = options;
 
-    console.log('Received outputs: ', transaction.outputs);
     const bytecode = witnesses[transaction.bytecodeWitnessIndex];
     const contractOutput = transaction.outputs.find(
       (output) => output.type === OutputType.ContractCreated,

--- a/packages/sdk/src/modules/transfers/DeployTransfer.ts
+++ b/packages/sdk/src/modules/transfers/DeployTransfer.ts
@@ -1,12 +1,15 @@
 import { BaseTransfer, BaseTransferLike } from './BaseTransfer';
 import {
+  Address,
   bn,
+  calculateGasFee,
   CoinTransactionRequestInput,
   ContractUtils,
   CreateTransactionRequest,
   hexlify,
   OutputType,
   Provider,
+  ScriptTransactionRequest,
   TransactionCreate,
   TransactionRequest,
   transactionRequestify,
@@ -22,6 +25,7 @@ import {
 
 import { Vault } from '../vault';
 import { clone } from 'ramda';
+import { FAKE_WITNESSES } from './helpers';
 
 /* Types */
 type BaseDeployTransfer = BaseTransferLike<CreateTransactionRequest>;
@@ -44,22 +48,18 @@ type DeployBakoTransaction = {
 const { getContractId, getContractStorageRoot } = ContractUtils;
 
 /* TODO: Move this method to vault */
-const getMaxPredicateGasUsed = async (
-  provider: Provider,
-  signers: number,
-  transactionRequest: TransactionRequest,
-) => {
-  const request = clone(transactionRequest);
-  const wallets = Array.from({ length: signers }, () =>
-    Wallet.generate({ provider }),
-  );
+const getMaxPredicateGasUsed = async (provider: Provider, signers: number) => {
+  const request = new ScriptTransactionRequest();
+  const addresses = Array.from({ length: signers }, () => Address.fromRandom());
   const vault = await Vault.create({
     configurable: {
       SIGNATURES_COUNT: signers,
-      SIGNERS: wallets.map((wallet) => wallet.address.toB256()),
+      SIGNERS: addresses.map((address) => address.toB256()),
       network: provider.url,
     },
   });
+
+  // Add fake input
   request.addCoinInput({
     id: ZeroBytes32,
     assetId: ZeroBytes32,
@@ -68,17 +68,20 @@ const getMaxPredicateGasUsed = async (
     blockCreated: bn(),
     txCreatedIdx: bn(),
   });
-  vault.populateTransactionPredicateData(request);
 
-  const txId = request.getTransactionId(provider.getChainId());
-  const signatures = await Promise.all(
-    wallets.map((wallet) => wallet.signMessage(txId.slice(2))),
-  );
-  signatures.forEach((signature) => request.addWitness(signature));
+  // Populate the  transaction inputs with predicate data
+  vault.populateTransactionPredicateData(request);
+  Array.from({ length: signers }, () => request.addWitness(FAKE_WITNESSES));
+
   const transactionCost = await vault.provider.getTransactionCost(request);
   await vault.fund(request, transactionCost);
   await vault.provider.estimatePredicates(request);
-  return request.maxFee;
+  const input = request.inputs[0];
+  if ('predicate' in input && input.predicate) {
+    return bn(input.predicateGasUsed);
+  }
+
+  return bn();
 };
 
 /**
@@ -152,7 +155,7 @@ export class DeployTransfer extends BaseTransfer<CreateTransactionRequest> {
   static async createTransactionRequest(
     options: DeployTransferTransactionRequest,
   ): Promise<CreateTransactionRequest> {
-    const { vault: account, inputs, witnesses, ...transaction } = options;
+    const { vault, inputs, witnesses, ...transaction } = options;
 
     const bytecode = witnesses[transaction.bytecodeWitnessIndex];
     const contractOutput = transaction.outputs.find(
@@ -172,30 +175,43 @@ export class DeployTransfer extends BaseTransfer<CreateTransactionRequest> {
       bytecodeWitnessIndex: transaction.bytecodeWitnessIndex,
     });
 
-    const fee = await getMaxPredicateGasUsed(
-      account.provider,
-      account.BakoSafeVault.minSigners,
-      transactionRequest,
-    );
-    transactionRequest.maxFee = fee;
-
+    // Get the transaction cost and set max fee to fund the transaction with required inputs
     const transactionCost =
-      await account.provider.getTransactionCost(transactionRequest);
-    transactionRequest = await account.fund(
-      transactionRequest,
-      transactionCost,
+      await vault.provider.getTransactionCost(transactionRequest);
+    transactionRequest.maxFee = transactionCost.maxFee;
+    transactionRequest = await vault.fund(transactionRequest, transactionCost);
+
+    // Estimate the gas usage for the predicate
+    const predicateGasUsed = await getMaxPredicateGasUsed(
+      vault.provider,
+      vault.BakoSafeVault.minSigners,
     );
 
-    if (transactionRequest.inputs.length > 1) {
-      console.log('Multiple inputs detected. Using the highest input amount.');
-      const highestInput = transactionRequest
-        .getCoinInputs()
-        .reduce((max, input) => {
-          return Number(max.amount) > Number(input.amount) ? max : input;
-        }, {} as CoinTransactionRequestInput);
-      transactionRequest.inputs = [highestInput];
-      console.log('Input amount: ', highestInput.amount.toString());
-    }
+    // Calculate the total gas usage for the transaction
+    let totalGasUsed = bn(0);
+    transactionRequest.inputs.forEach((input) => {
+      if ('predicate' in input && input.predicate) {
+        totalGasUsed = totalGasUsed.add(predicateGasUsed);
+      }
+    });
+
+    // Estimate the max fee for the transaction and calculate fee difference
+    const { gasPriceFactor } = await vault.provider.getGasConfig();
+    const { maxFee, gasPrice } = await vault.provider.estimateTxGasAndFee({
+      transactionRequest,
+    });
+
+    const predicateSuccessFeeDiff = calculateGasFee({
+      gas: totalGasUsed,
+      priceFactor: gasPriceFactor,
+      gasPrice,
+    });
+
+    const feeWithFat = maxFee.add(predicateSuccessFeeDiff);
+    transactionRequest.maxFee = feeWithFat;
+
+    // Attach missing inputs (including estimated predicate gas usage) / outputs to the request
+    await vault.provider.estimateTxDependencies(transactionRequest);
 
     return transactionRequest;
   }

--- a/packages/sdk/src/modules/vault/Vault.ts
+++ b/packages/sdk/src/modules/vault/Vault.ts
@@ -19,6 +19,7 @@ import {
   IBakoSafeIncludeTransaction,
   IConfVault,
   ICreationPayload,
+  IDeployContract,
   IPayloadVault,
   IVault,
 } from './types';
@@ -179,17 +180,18 @@ export class Vault extends Predicate<[]> implements IVault {
   /**
    * Include a new transaction in vault to deploy contract.
    *
-   * @param {TransactionCreate} transaction - The transaction details for deploying the contract.
+   * @param {IDeployContract} params - The transaction details for deploying the contract.
    * @returns {Promise<DeployTransfer>} A promise that resolves to an instance of DeployTransfer.
    */
   public async BakoSafeDeployContract(
-    transaction: TransactionCreate,
+    params: IDeployContract,
   ): Promise<DeployTransfer> {
+    const { name, ...transaction } = params;
     const transfer = await DeployTransfer.fromTransactionCreate({
       ...transaction,
       vault: this,
       auth: this.auth,
-      name: 'Contract deploy',
+      name: name || 'Contract deployment',
     });
 
     return transfer.save();

--- a/packages/sdk/src/modules/vault/types.ts
+++ b/packages/sdk/src/modules/vault/types.ts
@@ -1,4 +1,4 @@
-import { Provider, TransactionRequestLike } from 'fuels';
+import { Provider, TransactionCreate, TransactionRequestLike } from 'fuels';
 import { IBakoSafeAuth } from '../../api/auth/types';
 import {
   IListTransactions,
@@ -67,6 +67,10 @@ export interface ICreationNewVault {
 }
 
 export type ICreation = ICreationOldVault | ICreationNewVault;
+
+export type IDeployContract = TransactionCreate & {
+  name: string;
+};
 
 export type IBakoSafeIncludeTransaction =
   | IFormatTransfer

--- a/packages/sdk/test/__tests__/transfers-deploy.test.ts
+++ b/packages/sdk/test/__tests__/transfers-deploy.test.ts
@@ -129,9 +129,11 @@ describe('[TRANSFERS] Deploy', () => {
         BakoSafe.getGasConfig('MAX_FEE'),
       );
 
-      const deployTransfer = await vault.BakoSafeDeployContract(
-        transactionRequest.toTransaction(),
-      );
+      const transaction = transactionRequest.toTransaction();
+      const deployTransfer = await vault.BakoSafeDeployContract({
+        ...transaction,
+        name: '[TEST] Contract deploy',
+      });
 
       await signin(
         deployTransfer.getHashTxId(),
@@ -172,9 +174,11 @@ describe('[TRANSFERS] Deploy', () => {
         BakoSafe.getGasConfig('MAX_FEE'),
       );
 
-      const deployTransfer = await vault.BakoSafeDeployContract(
-        transactionRequest.toTransaction(),
-      );
+      const transaction = transactionRequest.toTransaction();
+      const deployTransfer = await vault.BakoSafeDeployContract({
+        ...transaction,
+        name: '[TEST] Contract deploy',
+      });
 
       expect(deployTransfer.getContractId()).toBe(contractId);
     },
@@ -207,9 +211,12 @@ describe('[TRANSFERS] Deploy', () => {
       BakoSafe.getGasConfig('MAX_FEE'),
     );
 
-    const deployTransfer = await vault.BakoSafeDeployContract(
-      transactionRequest.toTransaction(),
-    );
+    const transaction = transactionRequest.toTransaction();
+    const deployTransfer = await vault.BakoSafeDeployContract({
+      ...transaction,
+      name: '[TEST] Contract deploy',
+    });
+
     await signin(
       deployTransfer.getHashTxId(),
       'USER_1',
@@ -227,43 +234,4 @@ describe('[TRANSFERS] Deploy', () => {
     expect(apiDeployTransfer).toBeInstanceOf(DeployTransfer);
     expect(resume.status).toBe(TransactionStatus.SUCCESS);
   });
-
-  test.skip(
-    'Create a transaction request for deploy and send',
-    async () => {
-      const genesisWallet = Wallet.fromPrivateKey(
-        accounts['FULL'].privateKey,
-        provider,
-      );
-      const vault = await Vault.create({
-        ...auth['FULL'].BakoSafeAuth,
-        id: '886d984b-8971-4cd0-b098-177b5d4368b0',
-      });
-
-      const { transactionRequest, contractId: expectedContractId } =
-        await createTransactionDeploy(provider, vault);
-
-      const deployTransfer = await DeployTransfer.fromTransactionCreate({
-        ...transactionRequest.toTransaction(),
-        vault,
-        name: 'Contract deploy',
-      });
-
-      const signature = await genesisWallet.signMessage(
-        deployTransfer.getHashTxId(),
-      );
-      deployTransfer.transactionRequest.addWitness(signature);
-
-      await provider.estimatePredicates(deployTransfer.transactionRequest);
-      const response = await vault.sendTransaction(
-        deployTransfer.transactionRequest,
-      );
-      const deployed = await response.wait();
-
-      // const contractId = getContractId(request);
-
-      // expect(expectedContractId).toEqual(contractId);
-    },
-    1000 * 60 * 10,
-  );
 });


### PR DESCRIPTION
## Checklist
- [x] Change the method `vault.BakoSafeDeployContract` to receive the `TransactionCreate` and the name of transaction
- [x] Remove unused test
- [x] Remove logs  
- [x] Calculate the max fee by predicate gas used 